### PR TITLE
Fix Comparison validation on java to .equals()

### DIFF
--- a/.github/workflows/buildDeployBack.yml
+++ b/.github/workflows/buildDeployBack.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - dev
+    paths-ignore:
+      - "frontend/**"
+      - "db/**"
+      - "table_service/**"
 
 jobs:
   build-and-deploy-backend:

--- a/.github/workflows/buildDeployFront.yml
+++ b/.github/workflows/buildDeployFront.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - dev
+    paths-ignore:
+      - "backend/**"
+      - "db/**"
+      - "table_service/**"
 
 jobs:
   build-and-deploy-frontend:

--- a/.github/workflows/testFrontend.yml
+++ b/.github/workflows/testFrontend.yml
@@ -32,6 +32,10 @@ jobs:
           cache: yarn
           cache-dependency-path: frontend/yarn.lock
 
+      - name: Instala dependências yarn
+        run: yarn install
+        working-directory: frontend
+
       - name: Executa Lint
         run: yarn lint
         working-directory: frontend

--- a/.github/workflows/testFrontend.yml
+++ b/.github/workflows/testFrontend.yml
@@ -28,8 +28,9 @@ jobs:
       - name: Configura Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
-          cache: "yarn"
+          node-version: 22.x
+          cache: yarn
+          cache-dependency-path: frontend/yarn.lock
 
       - name: Executa Lint
         run: yarn lint

--- a/backend/src/main/java/com/storecontrol/backend/services/customers/component/CustomerFinalizationValidation.java
+++ b/backend/src/main/java/com/storecontrol/backend/services/customers/component/CustomerFinalizationValidation.java
@@ -24,7 +24,7 @@ public class CustomerFinalizationValidation {
             MessageResolver.getInstance().getMessage("validation.customerFinalization.checkVoluntary.functionNull.message")
         );
       } else {
-        if (!(voluntary.getFunction().getUuid() == function.getUuid())) {
+        if (!(voluntary.getFunction().getUuid().equals(function.getUuid()))) {
           throw new InvalidOperationException(
               MessageResolver.getInstance().getMessage("validation.customerFinalization.checkVoluntary.functionDifferent.error"),
               MessageResolver.getInstance().getMessage("validation.customerFinalization.checkVoluntary.functionDifferent.message")

--- a/backend/src/main/java/com/storecontrol/backend/services/operations/validation/PurchaseValidation.java
+++ b/backend/src/main/java/com/storecontrol/backend/services/operations/validation/PurchaseValidation.java
@@ -177,7 +177,7 @@ public class PurchaseValidation {
   }
 
   public void checkPurchaseBelongsToVoluntary(Purchase purchase, UUID userUuid) {
-    if (purchase.getVoluntary().getVoluntaryRole().isNotAdmin() && purchase.getVoluntary().getUuid() != userUuid) {
+    if (purchase.getVoluntary().getVoluntaryRole().isNotAdmin() && !purchase.getVoluntary().getUuid().equals(userUuid)) {
       throw new InvalidOperationException(
           MessageResolver.getInstance().getMessage("validation.purchase.checkVoluntary.notOwner.error"),
           MessageResolver.getInstance().getMessage("validation.purchase.checkVoluntary.notOwner.message")
@@ -190,7 +190,7 @@ public class PurchaseValidation {
       Optional<Purchase> optionalPurchase = repository.findLastFromVoluntary(voluntary.getUuid());
 
       if (optionalPurchase.isPresent()) {
-        if (optionalPurchase.get().getUuid() != purchase.getUuid()) {
+        if (!optionalPurchase.get().getUuid().equals(purchase.getUuid())) {
           throw new InvalidOperationException(
               MessageResolver.getInstance().getMessage("validation.purchase.checkLastPurchase.notLast.error"),
               MessageResolver.getInstance().getMessage("validation.purchase.checkLastPurchase.notLast.message")

--- a/backend/src/main/java/com/storecontrol/backend/services/operations/validation/RechargeValidation.java
+++ b/backend/src/main/java/com/storecontrol/backend/services/operations/validation/RechargeValidation.java
@@ -26,7 +26,7 @@ public class RechargeValidation {
             MessageResolver.getInstance().getMessage("validation.recharge.checkVoluntary.functionNull.message")
         );
       } else {
-        if (!(voluntary.getFunction().getUuid() == function.getUuid())) {
+        if (!(voluntary.getFunction().getUuid().equals(function.getUuid()))) {
           throw new InvalidOperationException(
               MessageResolver.getInstance().getMessage("validation.recharge.checkVoluntary.functionDifferent.error"),
               MessageResolver.getInstance().getMessage("validation.recharge.checkVoluntary.functionDifferent.message")
@@ -49,7 +49,7 @@ public class RechargeValidation {
   }
 
   public void checkRechargeBelongsToVoluntary(Recharge recharge, UUID userUuid) {
-    if (recharge.getVoluntary().getVoluntaryRole().isNotAdmin() && recharge.getVoluntary().getUuid() != userUuid) {
+    if (recharge.getVoluntary().getVoluntaryRole().isNotAdmin() && !recharge.getVoluntary().getUuid().equals(userUuid)) {
       throw new InvalidOperationException(
           MessageResolver.getInstance().getMessage("validation.recharge.checkVoluntary.notOwner.error"),
           MessageResolver.getInstance().getMessage("validation.recharge.checkVoluntary.notOwner.message")
@@ -62,7 +62,7 @@ public class RechargeValidation {
       Optional<Recharge> optionalRecharge = repository.findLastFromVoluntary(voluntary.getUuid());
 
       if (optionalRecharge.isPresent()) {
-        if (optionalRecharge.get().getUuid() != recharge.getUuid()) {
+        if (!optionalRecharge.get().getUuid().equals(recharge.getUuid())) {
           throw new InvalidOperationException(
               MessageResolver.getInstance().getMessage("validation.recharge.checkLastPurchase.notLast.error"),
               MessageResolver.getInstance().getMessage("validation.recharge.checkLastPurchase.notLast.message")

--- a/backend/src/main/java/com/storecontrol/backend/services/operations/validation/TransactionValidation.java
+++ b/backend/src/main/java/com/storecontrol/backend/services/operations/validation/TransactionValidation.java
@@ -55,7 +55,7 @@ public class TransactionValidation {
   }
 
   public void checkTransactionBelongsToVoluntary(Transaction transaction, UUID userUuid) {
-    if (transaction.getVoluntary().getVoluntaryRole().isNotAdmin() && transaction.getVoluntary().getUuid() != userUuid) {
+    if (transaction.getVoluntary().getVoluntaryRole().isNotAdmin() && !transaction.getVoluntary().getUuid().equals(userUuid)) {
       throw new InvalidOperationException(
           MessageResolver.getInstance().getMessage("validation.transaction.checkVoluntary.notOwner.error"),
           MessageResolver.getInstance().getMessage("validation.transaction.checkVoluntary.notOwner.message")
@@ -68,7 +68,7 @@ public class TransactionValidation {
       Optional<Transaction> optionalTransaction = repository.findLastFromVoluntary(voluntary.getUuid());
 
       if (optionalTransaction.isPresent()) {
-        if (optionalTransaction.get().getUuid() != transaction.getUuid()) {
+        if (!optionalTransaction.get().getUuid().equals(transaction.getUuid())) {
           throw new InvalidOperationException(
               MessageResolver.getInstance().getMessage("validation.transaction.checkLastTransaction.notLast.error"),
               MessageResolver.getInstance().getMessage("validation.transaction.checkLastPurchase.notLast.message")

--- a/backend/src/main/java/com/storecontrol/backend/services/stands/validation/ProductValidation.java
+++ b/backend/src/main/java/com/storecontrol/backend/services/stands/validation/ProductValidation.java
@@ -41,7 +41,7 @@ public class ProductValidation {
         userUuid.toString())
     );
     if (manager.getVoluntaryRole().isNotAdmin()) {
-      if (manager.getFunction().getUuid() != standUuid) {
+      if (!manager.getFunction().getUuid().equals(standUuid)) {
         throw new InvalidDatabaseInsertionException(
             MessageResolver.getInstance().getMessage("validation.product.checkManageFunction.invalidStand.error"),
             MessageResolver.getInstance().getMessage("validation.product.checkManageFunction.invalidStand.message"),

--- a/backend/src/main/java/com/storecontrol/backend/services/volunteers/validation/VoluntaryValidation.java
+++ b/backend/src/main/java/com/storecontrol/backend/services/volunteers/validation/VoluntaryValidation.java
@@ -83,8 +83,12 @@ public class VoluntaryValidation {
         MessageResolver.getInstance().getMessage("service.exception.voluntary.get.validation.error"),
         MessageResolver.getInstance().getMessage("service.exception.voluntary.get.validation.message"),
         managerUuid.toString()));
+    var voluntary = repository.findByUuidValidTrue(request.uuid()).orElseThrow(() -> new InvalidDatabaseQueryException(
+        MessageResolver.getInstance().getMessage("service.exception.voluntary.get.validation.error"),
+        MessageResolver.getInstance().getMessage("service.exception.voluntary.get.validation.message"),
+        request.uuid().toString()));
     if (manager.getVoluntaryRole().isNotAdmin()){
-      if (manager.getFunction().getUuid() != request.functionUuid()) {
+      if (request.functionUuid() != null && !manager.getFunction().getUuid().equals(request.functionUuid())) {
         // Stand validation
         if (manager.getFunction() instanceof Stand) {
           throw new InvalidDatabaseInsertionException(
@@ -111,6 +115,32 @@ public class VoluntaryValidation {
                 Map.of(
                     MessageResolver.getInstance().getMessage("validation.voluntary.checkManageFunction.invalidCashRegister.field"),
                     request.functionUuid().toString()
+                )
+            );
+          }
+        }
+      }
+      else if (request.functionUuid() == null && !voluntary.getFunction().getUuid().equals(managerUuid)) {
+        // Stand validation
+        if (voluntary.getFunction() instanceof Stand) {
+          throw new InvalidDatabaseInsertionException(
+              MessageResolver.getInstance().getMessage("validation.voluntary.checkManageFunction.invalidStand.error"),
+              MessageResolver.getInstance().getMessage("validation.voluntary.checkManageFunction.invalidStand.message"),
+              Map.of(
+                  MessageResolver.getInstance().getMessage("validation.voluntary.checkManageFunction.invalidStand.field"),
+                  "null"
+              )
+          );
+        }
+        // CashRegister validation
+        else {
+          if (manager.getFunction() instanceof Stand) {
+            throw new InvalidDatabaseInsertionException(
+                MessageResolver.getInstance().getMessage("validation.voluntary.checkManageFunction.invalidCashRegister.error"),
+                MessageResolver.getInstance().getMessage("validation.voluntary.checkManageFunction.invalidCashRegister.message"),
+                Map.of(
+                    MessageResolver.getInstance().getMessage("validation.voluntary.checkManageFunction.invalidCashRegister.field"),
+                    "null"
                 )
             );
           }


### PR DESCRIPTION
# Fix comparison validation of UUID on java

- Fix comparison on backend validation
 1. Customer Finalization
 2. Purchase
 3. Recharge
 4. Transaction
 5. Product
 6. Voluntary
- Update github actions, workflow for deploy to trigger only on change of service files