### PR TITLE
Fix voluntary update and security endpoint list (update frontend workflow)

### DIFF
--- a/.github/workflows/buildDeployFront.yml
+++ b/.github/workflows/buildDeployFront.yml
@@ -34,8 +34,8 @@ jobs:
           build-args: |
             VITE_BACKEND_BASE_URL=${{ vars.VITE_BACKEND_BASE_URL }}
             VITE_SYSTEM_VERSION=${{ vars.VITE_SYSTEM_VERSION }}
-            VITE_ORDER_CARD_ID_FIXED="OrderCardSimple"
-            VITE_CASH_REGISTER_UUID_FIXED="12345678-abcd-4efa-bcde-f1234567890a"
+            VITE_ORDER_CARD_ID_FIXED=${{ vars.VITE_ORDER_CARD_ID_FIXED }}
+            VITE_CASH_REGISTER_UUID_FIXED=${{ vars.VITE_CASH_REGISTER_UUID_FIXED }}
 
       - name: Aguardar a disponibilidade da imagem
         run: sleep 10

--- a/backend/src/main/java/com/storecontrol/backend/config/security/SecurityConfigurations.java
+++ b/backend/src/main/java/com/storecontrol/backend/config/security/SecurityConfigurations.java
@@ -94,7 +94,7 @@ public class SecurityConfigurations {
       "/products/list/{standUuid}",
       "/products/{uuid}",
       "/stands/list",
-      "/tags",
+      "/tags/list",
       "/customers/card/{cardId}"
   };
 

--- a/backend/src/main/java/com/storecontrol/backend/models/volunteers/Voluntary.java
+++ b/backend/src/main/java/com/storecontrol/backend/models/volunteers/Voluntary.java
@@ -84,7 +84,7 @@ public class Voluntary implements UserDetails {
     }
   }
 
-  public void updateVoluntary(Function function){
+  public void updateVoluntaryFunction(Function function){
     this.function = function;
   }
 

--- a/backend/src/main/java/com/storecontrol/backend/services/volunteers/VoluntaryService.java
+++ b/backend/src/main/java/com/storecontrol/backend/services/volunteers/VoluntaryService.java
@@ -74,7 +74,7 @@ public class VoluntaryService {
 
   @Transactional
   public Voluntary updateVoluntary(RequestUpdateVoluntary request) {
-    Voluntary voluntary = (Voluntary) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    var voluntary = safeTakeVoluntaryByUuid(request.uuid());
     validation.checkVoluntaryAuthentication(request.uuid(), voluntary);
     validation.checkNameDuplication(request.username(), request.fullname());
     validation.checkRootFullname(request.uuid(), request.fullname());
@@ -122,9 +122,9 @@ public class VoluntaryService {
     if (uuid != null) {
       var function = functionService.takeFunctionByUuid(uuid);
 
-      voluntary.updateVoluntary(function);
+      voluntary.updateVoluntaryFunction(function);
     } else {
-      voluntary.updateVoluntary(null);
+      voluntary.updateVoluntaryFunction(null);
     }
   }
 }

--- a/backend/src/test/java/com/storecontrol/backend/controllers/volunteers/VoluntaryTest.java
+++ b/backend/src/test/java/com/storecontrol/backend/controllers/volunteers/VoluntaryTest.java
@@ -106,7 +106,7 @@ class VoluntaryTest extends BaseTest {
         mockVoluntary.getUuid(),
         mockStand.getUuid());
 
-    mockVoluntary.updateVoluntary(mockStand);
+    mockVoluntary.updateVoluntaryFunction(mockStand);
     ResponseVoluntary expectedResponse = new ResponseVoluntary(mockVoluntary);
 
     when(service.updateFunctionFromVoluntary(updateRequest)).thenReturn(mockVoluntary);


### PR DESCRIPTION
## Fix voluntary uptade
- Voluntary update now get hibernate entity, therefore JPA can identify and update on database.

## Update security list
- Add tags list to the security endpoint list.

## Update frontend build workflow
- Use order card and register id from actions variable.